### PR TITLE
Change colors_name variable to codeschool for codeschool theme

### DIFF
--- a/CodeSchool/Vim/codeschool.vim
+++ b/CodeSchool/Vim/codeschool.vim
@@ -9,7 +9,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "Code School 3"
+let g:colors_name = "codeschool"
 
 hi Cursor ctermfg=16 ctermbg=145 cterm=NONE guifg=#182227 guibg=#9ea7a6 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#3f4b52 gui=NONE


### PR DESCRIPTION
Many of the pre-repo copies of this theme have changed the colors_name variable to codeschool because of errors such as the one below.

```
Error detected while processing /usr/local/Cellar/macvim/HEAD/MacVim.app/Contents/Resources/vim/runtime/syntax/synload.vim:5 - 
line   19:
E185: Cannot find color scheme 'Code School 3'
```

In populating some menu for theme selection, MacVim apparently expects the `colors_name` variable to be identical to the file name. This error has noticed but it has never been pushed upstream as there was no upstream from @AstonJ until recently. Other users on GitHub have patched their copies of the theme to silence the error:

* https://github.com/antlypls/vim-colors-codeschool/commit/27e95bc21caf06edec42ec60547871c72ca42232

* https://github.com/29decibel/codeschool-vim-theme/commit/880cc5470dace0fb5de204d68a918a6fdc61232d

This is the a patch to get this fix upstream which resulted from the discussion here:

https://github.com/flazz/vim-colorschemes/pull/64#issuecomment-124900792